### PR TITLE
BLOCK-1602 removed serialNumber from token metadata files + minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,9 @@ The `upload.json` file contains all metadata (collection name, factory/token has
     },
     "environment": {
         "env": "production",
-        "url": "https://www.my-nft-website.com"
+        "tokenUriTemplate": "{serial_number}",
+        "url": "https://www.my-nft-website.com",
+        "toolVersion": "1.4.0"
     }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "metadata-tool",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "description": "",
     "main": "index.ts",
     "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,11 +16,13 @@ import { NFTData } from './types';
 import { outputJsonFiles } from './utils/outputJsonFiles';
 import { UploadOutput } from './types/uploadOutput';
 import { UrlMapper } from './utils/urlMapper';
+const { version } = require('../package.json');
 
 const glob = promisify(globMod);
 
 const main = async () => {
-    ReportGenerator.add('Started Program', false);
+    const VERSION = version;
+    ReportGenerator.add(`Started Metadata Tool v${VERSION}`, true);
     ExitHandlers.init();
 
     let fileType: 'csv' | 'json' = 'csv';
@@ -97,13 +99,6 @@ const main = async () => {
         await promptUser(errorMessage);
         return;
     }
-
-    // if (!isCSV && !files.includes(`defaultToken.json`)) {
-    //     const errorMessage = ErrorGenerator.get('MISSING_DEFAULT_TOKEN_FILE', '.json');
-    //     ReportGenerator.add(errorMessage);
-    //     await promptUser(errorMessage);
-    //     return;
-    // }
 
     // if processing csv files, notify if tokens file is present
     if (isCSV && files.includes(`tokens.${fileType}`)) {
@@ -254,6 +249,7 @@ const main = async () => {
                 env: config.environment,
                 tokenUriTemplate: nftData.factory.tokenUriTemplate,
                 url: config.environmentUrl,
+                toolVersion: VERSION,
             },
         };
 

--- a/src/types/uploadOutput.ts
+++ b/src/types/uploadOutput.ts
@@ -21,6 +21,7 @@ export interface UploadOutput {
         env: string;
         url: string;
         tokenUriTemplate: '{serial_number}' | '{hash}'; // The uri template to follow to tokens - either "{serial_number}" or "{hash}"
+        toolVersion: string | undefined; // Version of this tool. Taken from package.json
     };
 
     /**

--- a/src/utils/outputJsonFiles.ts
+++ b/src/utils/outputJsonFiles.ts
@@ -35,10 +35,15 @@ export async function outputJsonFiles(
     };
 
     if (data.defaultToken) {
+        // Don't include defaultToken.serialNumber when writing to file
         ReportGenerator.add(`Writing defaultToken.json to file.`);
-        fs.writeFileSync(paths.defaultToken, JSON.stringify(data.defaultToken, null, 2));
+        fs.writeFileSync(
+            paths.defaultToken,
+            JSON.stringify({ ...data.defaultToken, serialNumber: undefined }, null, 2)
+        );
     }
 
+    // Don't include factory.tokenUriTemplate when writing to file
     ReportGenerator.add(`Writing factory.json to file.`);
     fs.writeFileSync(paths.factory, JSON.stringify({ ...data.factory, tokenUriTemplate: undefined }, null, 2));
 
@@ -76,8 +81,9 @@ export async function outputJsonFiles(
     for (let token of data.tokens) {
         const tokenPath = normalizeUrl(path.join(workingDirectory, `/${token.serialNumber}.token.json`));
 
+        // Don't include token.serialNumber when writing to file
         ReportGenerator.add(`Writing ${token.serialNumber}.token.json to file.`);
-        fs.writeFileSync(tokenPath, JSON.stringify(token, null, 2));
+        fs.writeFileSync(tokenPath, JSON.stringify({ ...token, serialNumber: undefined }, null, 2));
 
         const tokenHash = await HashGenerator.create(tokenPath);
         if (typeof tokenHash === 'undefined') {


### PR DESCRIPTION
JIRA Ticket: [BLOCK-1602](https://ultraio.atlassian.net/browse/BLOCK-1602)

- Removed `serialNumber` property from token metadata files.

[BLOCK-1602]: https://ultraio.atlassian.net/browse/BLOCK-1602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ