### PR TITLE
Fix: integrity builder and rename media content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # Metadata Tool
 
-- [Metadata Tool](#metadata-tool)
-  - [Overview](#overview)
-  - [Obtaining the tool](#obtaining-the-tool)
-    - [Downloading a release:](#downloading-a-release)
-    - [Building a binary/executable:](#building-a-binaryexecutable)
-  - [Configuration file](#configuration-file)
-  - [How to use](#how-to-use)
-    - [Setup Folder Structure:](#setup-folder-structure)
-    - [Setup CSV Template:](#setup-csv-template)
-    - [Image/Media Pathing:](#imagemedia-pathing)
-    - [Supported Media Types:](#supported-media-types)
-    - [Running the tool:](#running-the-tool)
-    - [Output file structure:](#output-file-structure)
-  - [License](#license)
+-   [Metadata Tool](#metadata-tool)
+    -   [Overview](#overview)
+    -   [Obtaining the tool](#obtaining-the-tool)
+        -   [Downloading a release:](#downloading-a-release)
+        -   [Building a binary/executable:](#building-a-binaryexecutable)
+    -   [Configuration file](#configuration-file)
+    -   [How to use](#how-to-use)
+        -   [Setup Folder Structure:](#setup-folder-structure)
+        -   [Setup CSV Template:](#setup-csv-template)
+        -   [Image/Media Pathing:](#imagemedia-pathing)
+        -   [Supported Media Types:](#supported-media-types)
+        -   [Note for media files:](#note-for-media-files)
+        -   [Running the tool:](#running-the-tool)
+        -   [Output file structure:](#output-file-structure)
 
 ---
 
@@ -141,6 +141,10 @@ The tool currently only supports the follow media types:
 -   webm
 -   json
 
+### Note for media files:
+
+All media files are copied and renamed to their hash value. For example, if you have a media file `/factory/sq.png`, it will be copied, and renamed to `/generated_media/<hash>.png`.
+
 ### Running the tool:
 
 Once the CSV files and all related images/media files are present in the folder, you can process the folder for JSON creation.
@@ -183,13 +187,11 @@ The `upload.json` file contains all metadata (collection name, factory/token has
         }
     ],
     "media": {
-        "factory/sq.png": "https://www.my-nft-website.com/MyFirstUniq/<hash-of-file>.png",
-        "factory/product.png": "https://www.my-nft-website.com/MyFirstUniq/<hash-of-file>.png",
-        "factory/gallery/1.png": "https://www.my-nft-website.com/MyFirstUniq/<hash-of-file>.png",
-        "tokens/1/image.png": "https://www.my-nft-website.com/MyFirstUniq/<hash-of-file>.png",
-        "tokens/1/gallery/1.png": "https://www.my-nft-website.com/MyFirstUniq/<hash-of-file>.png",
-        "tokens/2/image.png": "https://www.my-nft-website.com/MyFirstUniq/<hash-of-file>.png",
-        "tokens/2/gallery/1.png": "https://www.my-nft-website.com/MyFirstUniq/<hash-of-file>.png"
+        "generated_media/<hash-of-file1>.png": "https://www.my-nft-website.com/MyFirstUniq/<hash-of-file1>.png",
+        "generated_media/<hash-of-file2>.png": "https://www.my-nft-website.com/MyFirstUniq/<hash-of-file2>.png",
+        "generated_media/<hash-of-file3>.png": "https://www.my-nft-website.com/MyFirstUniq/<hash-of-file3>.png",
+         .....
+         .....
     },
     "environment": {
         "env": "production",
@@ -201,4 +203,3 @@ The `upload.json` file contains all metadata (collection name, factory/token has
 ```
 
 Note that the URLs provided in the output file are based on the environment URIs that were provided to the program. These URLs are where your Uniq metadata files _should_ be hosted/uploaded.
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "metadata-tool",
-    "version": "1.4.4",
+    "version": "1.4.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "metadata-tool",
-            "version": "1.4.4",
+            "version": "1.4.6",
             "license": "ISC",
             "dependencies": {
                 "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "metadata-tool",
-    "version": "1.4.5",
+    "version": "1.4.6",
     "description": "",
     "main": "index.ts",
     "scripts": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,10 +5,13 @@ import { ReportGenerator } from './utils/reportGenerator';
 // List of all available envs and their corresponding url
 let envUrlMapping = {};
 
+export const DEFAULT_GENERATED_MEDIA_DIR = 'generated_media';
+
 export interface Config {
     environment: string | undefined; // Current env
     environmentUrl: string | undefined; // Current env url
     collectionName: string | undefined;
+    generatedMediaDir: string; // Path to generated media files
 }
 
 let defaultConfig: Config | undefined = undefined;
@@ -40,6 +43,7 @@ export function getConfig(): Config | undefined {
         environment: undefined,
         environmentUrl: undefined,
         collectionName: undefined,
+        generatedMediaDir: DEFAULT_GENERATED_MEDIA_DIR,
     };
 
     // Load all envs from config.json

--- a/src/utils/csvParser.ts
+++ b/src/utils/csvParser.ts
@@ -45,12 +45,14 @@ const Internal = {
         metadata.media = {
             product: {
                 contentType: pathToMimeType(record['product']),
-                integrity: null,
+                // Temporary hash value, only for schema validation purposes. Will be replaced by the actual hash later by the integrityBuilder
+                integrity: { type: 'SHA256', hash: '7cfe7bb3fc62c0ba4706ec1a2f78b3c8845c2985aa99bdefebae8fe18ea835e5' },
                 uris: [record['product']],
             },
             square: {
                 contentType: pathToMimeType(record['square']),
-                integrity: null,
+                // Temporary hash value, only for schema validation purposes. Will be replaced by the actual hash later by the integrityBuilder
+                integrity: { type: 'SHA256', hash: '7cfe7bb3fc62c0ba4706ec1a2f78b3c8845c2985aa99bdefebae8fe18ea835e5' },
                 uris: [record['square']],
             },
         };
@@ -58,7 +60,8 @@ const Internal = {
         if (record['hero']) {
             metadata.media.hero = {
                 contentType: pathToMimeType(record['hero']),
-                integrity: null,
+                // Temporary hash value, only for schema validation purposes. Will be replaced by the actual hash later by the integrityBuilder
+                integrity: { type: 'SHA256', hash: '7cfe7bb3fc62c0ba4706ec1a2f78b3c8845c2985aa99bdefebae8fe18ea835e5' },
                 uris: [record['hero']],
             };
         }
@@ -81,7 +84,11 @@ const Internal = {
             if (element) {
                 result.push({
                     contentType: pathToMimeType(element),
-                    integrity: null,
+                    // Temporary hash value, only for schema validation purposes. Will be replaced by the actual hash later by the integrityBuilder
+                    integrity: {
+                        type: 'SHA256',
+                        hash: '7cfe7bb3fc62c0ba4706ec1a2f78b3c8845c2985aa99bdefebae8fe18ea835e5',
+                    },
                     uris: [element],
                 });
             }

--- a/src/utils/integrityBuilder.ts
+++ b/src/utils/integrityBuilder.ts
@@ -33,9 +33,6 @@ export async function buildHashes<T>(data: Object, workingDirectory: string): Pr
     // Finds Static Resource Objects & Creates Hashes
     if (objectHasKeys(data, StaticResourceKeys)) {
         const typedData = <StaticResource>data;
-        if (typedData.integrity !== null) {
-            return typedData as T;
-        }
 
         if (typedData.uris.length <= 0) {
             return typedData as T;
@@ -45,6 +42,7 @@ export async function buildHashes<T>(data: Object, workingDirectory: string): Pr
         for (let i = 0; i < typedData.uris.length; i++) {
             const newHash = await HashGenerator.create(typedData.uris[i], workingDirectory);
             if (typeof newHash === 'undefined') {
+                typedData.integrity = null;
                 return typedData as T;
             }
 

--- a/src/utils/urlReplace.ts
+++ b/src/utils/urlReplace.ts
@@ -1,8 +1,10 @@
+import fs from 'fs';
+import path from 'path';
+import { Config } from 'config';
 import { StaticResource } from '../types';
 import { UrlMapper } from './urlMapper';
-
 /**
- * Walk through a given object, and build integrity for all StaticResource objects.
+ * Walk through a given object, replacing all URLs with the corresponding S3/Wasabi/Hosting service URLs.
  *
  * @export
  * @template T
@@ -10,12 +12,7 @@ import { UrlMapper } from './urlMapper';
  * @param {string} workingDirectory
  * @return {Promise<T>}
  */
-export async function replaceUrls<T>(
-    data: Object,
-    workingDirectory: string,
-    collectionName: string,
-    environmentURL: string
-): Promise<T> {
+export async function replaceUrls<T>(data: Object, workingDirectory: string, config: Config): Promise<T> {
     // Perform replacement, return result
     if (data.hasOwnProperty('uris')) {
         const typedData = <StaticResource>data;
@@ -24,18 +21,31 @@ export async function replaceUrls<T>(
                 continue;
             }
 
+            if (!typedData.integrity?.hash) {
+                throw new Error(`Integrity hash not found for ${typedData.uris[i]}`);
+            }
+
+            const filePath = path.join(workingDirectory, typedData.uris[i]).replace(/\\/gm, '/');
             const splitString = typedData.uris[i].split('.');
             const extension = splitString[splitString.length - 1];
-            const finalURL = `${environmentURL}/${encodeURIComponent(collectionName.replace(/\s/g, ''))}/${
-                typedData.integrity?.hash
-            }.${extension}`
+            const finalURL = `${config.environmentUrl}/${encodeURIComponent(
+                config.collectionName!.replace(/\s/g, '')
+            )}/${typedData.integrity.hash}.${extension}`
                 // To remove any query params (if they exist on any external urls) from the output url (output url in this case is the url of S3/Wasabi buckets)
                 // This will fix, for eg:
                 // input url ---> https://www.somewebsite.com/5000.jpg?width=1200&quality=85&auto=format&fit=max&token=0c4de651644de5fe939d8dbd6b14ba66
                 // output url ---> https://my-custom-env.s3.amazonaws.com/CollectionName/<file-hash>.jpg
                 .split('?')[0];
 
-            UrlMapper.set(typedData.uris[i], finalURL);
+            // We need to rename each media file to its hash value.
+            // For example, if the file is 5000.jpg, we need to rename it to <hash>.jpg
+            // But we're not going to rename the original file, well just copy it to the new file name.
+            const newFilePath = path
+                .join(workingDirectory, config.generatedMediaDir, typedData.integrity.hash + '.' + extension)
+                .replace(/\\/gm, '/');
+            fs.copyFileSync(filePath, newFilePath);
+
+            UrlMapper.set(path.join(config.generatedMediaDir, path.basename(newFilePath)), finalURL);
             typedData.uris[i] = finalURL;
         }
 
@@ -49,12 +59,12 @@ export async function replaceUrls<T>(
         }
 
         if (!Array.isArray(data[key])) {
-            data[key] = await replaceUrls<T>(data[key], workingDirectory, collectionName, environmentURL);
+            data[key] = await replaceUrls<T>(data[key], workingDirectory, config);
             continue;
         }
 
         for (let i = 0; i < data[key].length; i++) {
-            data[key][i] = await replaceUrls<T>(data[key][i], workingDirectory, collectionName, environmentURL);
+            data[key][i] = await replaceUrls<T>(data[key][i], workingDirectory, config);
         }
     }
 

--- a/test/csvProcessing.test.ts
+++ b/test/csvProcessing.test.ts
@@ -37,7 +37,10 @@ describe('csv processing test', () => {
         expect(typeof data.factory !== 'undefined').toBe(true);
         expect(typeof data.factory.defaultLocale).toBe('string');
         expect(typeof data.factory.attributes).toBe('object');
-        expect(data.factory.media.product.integrity).toBe(null);
+        expect(data.factory.media.product.integrity).toBeTruthy();
+        expect(data.factory.media.product.integrity?.hash).toBe(
+            '7cfe7bb3fc62c0ba4706ec1a2f78b3c8845c2985aa99bdefebae8fe18ea835e5'
+        );
     });
 
     test('validate default token data', () => {
@@ -46,7 +49,10 @@ describe('csv processing test', () => {
             expect(typeof data.defaultToken.name).toBe('string');
             expect(typeof data.defaultToken.defaultLocale).toBe('string');
             expect(typeof data.defaultToken.attributes).toBe('object');
-            expect(data.defaultToken.media.product.integrity).toBe(null);
+            expect(data.defaultToken.media.product.integrity).toBeTruthy();
+            expect(data.defaultToken.media.product.integrity?.hash).toBe(
+                '7cfe7bb3fc62c0ba4706ec1a2f78b3c8845c2985aa99bdefebae8fe18ea835e5'
+            );
         }
     });
 
@@ -57,7 +63,10 @@ describe('csv processing test', () => {
 
         for (let i = 0; i < data.tokens.length; i++) {
             expect(data.tokens[i].serialNumber).toBe(String(i + 1));
-            expect(data.tokens[i].media.product.integrity).toBe(null);
+            expect(data.tokens[i].media.product.integrity).toBeTruthy();
+            expect(data.tokens[i].media.product.integrity?.hash).toBe(
+                '7cfe7bb3fc62c0ba4706ec1a2f78b3c8845c2985aa99bdefebae8fe18ea835e5'
+            );
         }
     });
 });

--- a/test/urlReplace.test.ts
+++ b/test/urlReplace.test.ts
@@ -1,26 +1,45 @@
 import path from 'path';
+import fs from 'fs';
 import { CSVParser } from '../src/utils/csvParser';
 import { buildHashes } from '../src/utils/integrityBuilder';
 import { NFTData } from '../src/types';
 import { replaceUrls } from '../src/utils/urlReplace';
-
+import { Config, getConfig } from '../src/config';
 const testPath = './test/csv';
 const folderPath = path.join(process.cwd(), testPath).replace(/\\/gm, '/');
 const collectionName = 'testing';
 const envUrl = 'https://whatever.com';
+const config: Config = {
+    environment: 'testing',
+    environmentUrl: envUrl,
+    collectionName: collectionName,
+    generatedMediaDir: 'test_generated_media',
+};
 
 let data: NFTData;
 let hashedData: NFTData;
 let updatedUrlsNftData: NFTData;
 
-describe('relative url repacement tests', () => {
+describe('relative url replacement tests', () => {
+    beforeAll(() => {
+        if (!fs.existsSync(path.join(folderPath, config.generatedMediaDir))) {
+            fs.mkdirSync(path.join(folderPath, config.generatedMediaDir));
+        }
+    });
+
+    afterAll(() => {
+        if (fs.existsSync(path.join(folderPath, config.generatedMediaDir))) {
+            fs.rmSync(path.join(folderPath, config.generatedMediaDir), { recursive: true, force: true });
+        }
+    });
+
     test('should build integrity first', async () => {
         data = await CSVParser.parse(folderPath);
         hashedData = await buildHashes<NFTData>(data, folderPath);
     });
 
     test('verify urls were converted based on collection name and env url', async () => {
-        updatedUrlsNftData = await replaceUrls<NFTData>(hashedData, folderPath, collectionName, envUrl);
+        updatedUrlsNftData = await replaceUrls<NFTData>(hashedData, folderPath, config!);
         expect(updatedUrlsNftData.defaultToken?.media.hero?.uris[0].includes(envUrl)).toBe(true);
         expect(updatedUrlsNftData.factory?.media.hero?.uris[0].includes(envUrl)).toBe(true);
         expect(updatedUrlsNftData.tokens[0]?.media.hero?.uris[0].includes(envUrl)).toBe(true);


### PR DESCRIPTION
- Fixed integrity builder. It was generating the default placeholder hash previously.
- Added functionality to auto copy and rename media files to their respective hash value.