### PR TITLE
fix `urlReplace` util to correctly handle external URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "metadata-tool",
-    "version": "1.4.6",
+    "version": "1.4.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "metadata-tool",
-            "version": "1.4.6",
+            "version": "1.4.7",
             "license": "ISC",
             "dependencies": {
                 "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "metadata-tool",
-    "version": "1.4.6",
+    "version": "1.4.7",
     "description": "",
     "main": "index.ts",
     "scripts": {

--- a/src/utils/urlReplace.ts
+++ b/src/utils/urlReplace.ts
@@ -17,7 +17,7 @@ export async function replaceUrls<T>(data: Object, workingDirectory: string, con
     if (data.hasOwnProperty('uris')) {
         const typedData = <StaticResource>data;
         for (let i = 0; i < typedData.uris.length; i++) {
-            if (typedData.uris.includes('http') || typedData.uris.includes('https')) {
+            if (typedData.uris[i].includes('http') || typedData.uris[i].includes('https')) {
                 continue;
             }
 


### PR DESCRIPTION
- fix `urlReplace` util to correctly handle external URLs
- Bump version to `1.4.7`